### PR TITLE
Add API link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Clojars Project](https://img.shields.io/clojars/v/namespacefy.svg)](https://clojars.org/namespacefy)  
 
-[API documentation](https://kauko.github.io/namespacefy/docs/)
+[API documentation](https://jarzka.github.io/namespacefy/docs/)
 
 namespacefy is a simple Clojure(Script) library which aims to make it easy to keep keys namespaced.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Clojars Project](https://img.shields.io/clojars/v/namespacefy.svg)](https://clojars.org/namespacefy)  
 
-(API documentation)[https://kauko.github.io/namespacefy/docs/]
+[API documentation](https://kauko.github.io/namespacefy/docs/)
 
 namespacefy is a simple Clojure(Script) library which aims to make it easy to keep keys namespaced.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # `namespacefy`
 
-[![Clojars Project](https://img.shields.io/clojars/v/namespacefy.svg)](https://clojars.org/namespacefy)
+[![Clojars Project](https://img.shields.io/clojars/v/namespacefy.svg)](https://clojars.org/namespacefy)  
+
+(API documentation)[https://kauko.github.io/namespacefy/docs/]
 
 namespacefy is a simple Clojure(Script) library which aims to make it easy to keep keys namespaced.
 


### PR DESCRIPTION
It's easy to generate API documentation with [Codox](https://github.com/weavejester/codox). I forked your library, added a gh-pages branch, and generated the documentation.

This PR adds a link to the top of the README.md, that will point to the documentation generated by Codox. You will need to accept this first, then add a gh-pages branch yourself, and then accept my second PR, that will actually add the documentation. I could only do the "gh-pages PR" against your master branch, we'll have to change that once you add the gh-pages branch.